### PR TITLE
Add try catch to avoid unicode decode exception in python 2.7.10

### DIFF
--- a/wikitables/util.py
+++ b/wikitables/util.py
@@ -7,7 +7,10 @@ def ftag(t):
 def ustr(s):
     if sys.version_info < (3, 0):
         #py2
-        return unicode(s).encode('utf-8')
+        try:
+            return unicode(s).encode('utf-8')
+        except UnicodeDecodeError:
+            return str(s)
     else:
         return str(s)
 


### PR DESCRIPTION
Hi, I tested your lib under Python 2.7.10, and was getting a crash with the following code:
`from wikitables import import_tables `
`tables = import_tables('List of postal codes')`
Wiki link: https://en.wikipedia.org/wiki/List_of_postal_codes

I'm guessing the error could be arising for some weird chars in the country names (e.g. Åland Islands). 
The code is trying to convert to unicode chars that already are _in_ unicode. I just wrapped the erroring line to catch the exception and avoid the unicoding in that case.

Let me know if this helps.

Thanks!

