### PR TITLE
Added support for custom wiki urls

### DIFF
--- a/wikitables/__init__.py
+++ b/wikitables/__init__.py
@@ -11,8 +11,8 @@ from wikitables.util import TableJSONEncoder, ftag, ustr
 log = logging.getLogger('wikitables')
 
 
-def import_tables(article, lang='en'):
-    client = Client(lang)
+def import_tables(article, base_url='wikipedia.org/w/api.php', lang='en'):
+    client = Client(base_url, lang)
     page = client.fetch_page(article)
     body = page['revisions'][0]['*']
 

--- a/wikitables/cli.py
+++ b/wikitables/cli.py
@@ -24,6 +24,11 @@ def main():
     parser.add_argument('-d', '--debug',
                         action='store_true',
                         help='enable debug output')
+    parser.add_argument('-u', '--base-url',
+                        action='store',
+                        dest='base_url',
+                        default='wikipedia.org/w/api.php',
+                        help='set the base url')
     parser.add_argument('article', help='article title')
 
     args = parser.parse_args()
@@ -38,7 +43,7 @@ def main():
     else:
         logging.basicConfig(level=logging.WARN)
 
-    tables = import_tables(args.article, lang=args.lang)
+    tables = import_tables(args.article, base_url=args.base_url, lang=args.lang)
     tables_dict = {table.name: table.rows for table in tables}
     if args.pretty:
         jprint(tables_dict)

--- a/wikitables/client.py
+++ b/wikitables/client.py
@@ -12,9 +12,12 @@ class ArticleNotFound(RuntimeError):
 class Client(requests.Session):
     """ Mediawiki API client """
 
-    def __init__(self, lang="en"):
+    def __init__(self, base_url='wikipedia.org/w/api/php', lang="en"):
         super(Client, self).__init__()
-        self.base_url = 'https://' + lang + '.wikipedia.org/w/api.php'
+        if base_url.startswith('wikipedia.org'):
+            self.base_url = f'https://{lang}.{base_url}'
+        else:
+            self.base_url = base_url
 
     def fetch_page(self, title, method='GET'):
         """ Query for page by title """


### PR DESCRIPTION
Support for wiki pages using custom urls by adding a `--base-url` flag in the cli and `base_url` parameter in `import_tables`.

For example with the wiki page: [https://www.theiphonewiki.com/wiki/Models](https://www.theiphonewiki.com/wiki/Models) the base url would be [https://www.theiphonewiki.com/w/api.php](https://www.theiphonewiki.com/w/api.php) with the article "Models".